### PR TITLE
Changes to fix the size and spacing of elements in the main activity

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,46 +7,47 @@
     android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
-    <LinearLayout
+    <RelativeLayout
         android:id="@+id/container_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
         android:orientation="vertical">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/mainToolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:layout_gravity="center_horizontal"
-            android:background="?attr/colorPrimary">
-
-            <LinearLayout
-                android:id="@+id/mainToolbarLayout"
-                android:layout_width="328dp"
-                android:layout_height="35dp"
-                android:layout_marginTop="10dp"
-                android:layout_marginEnd="10dp"
-                android:layout_marginBottom="10dp"
-                android:background="@drawable/search_background">
-
-                <fragment
-                    android:id="@+id/autocomplete_fragment"
-                    android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-            </LinearLayout>
+            android:background="?attr/colorPrimary"
+            app:contentInsetStart="0dp">
 
             <ImageButton
                 android:id="@+id/currentLocationButton"
                 android:layout_width="30dp"
                 android:layout_height="30dp"
-                android:background="@drawable/location_unpressed" />
+                android:background="@drawable/location_unpressed"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginEnd="15dp"/>
+
+            <RelativeLayout
+                android:id="@+id/mainToolbarLayout"
+                android:layout_width="match_parent"
+                android:layout_height="35dp"
+                android:background="@drawable/search_background"
+                android:layout_marginStart="15dp"
+                android:layout_marginEnd="10dp">
+
+                <fragment
+                    android:id="@+id/autocomplete_fragment"
+                    android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start"/>
+
+            </RelativeLayout>
 
         </androidx.appcompat.widget.Toolbar>
 
-    </LinearLayout>
+    </RelativeLayout>
 
 
     <com.lorentzos.flingswipe.SwipeFlingAdapterView
@@ -54,7 +55,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/container_toolbar"
-        app:rotation_degrees="15.5" />
+        app:rotation_degrees="15.5"
+        android:layout_above="@id/bottomNavigationBar"/>
 
     <RelativeLayout
         android:id="@+id/bottomNavigationBar"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -64,13 +64,12 @@
         android:background="@color/primary"
         android:padding="10dp">
 
+
         <ImageButton
             android:id="@+id/filterButton"
             android:layout_width="123dp"
             android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
             android:background="@color/transparent"
-            android:gravity="center"
             android:onClick="filterProperties"
             android:scaleType="fitCenter"
             android:src="@drawable/filter_list" />
@@ -79,19 +78,19 @@
             android:id="@+id/favoritesButton"
             android:layout_width="123dp"
             android:layout_height="wrap_content"
-            android:layout_toEndOf="@id/filterButton"
             android:background="@color/transparent"
             android:gravity="center"
             android:scaleType="fitCenter"
+            android:layout_centerHorizontal="true"
             android:src="@drawable/favorites_list_icon" />
+
 
         <ImageButton
             android:id="@+id/userInfoButton"
             android:layout_width="123dp"
             android:layout_height="wrap_content"
-            android:layout_toEndOf="@id/favoritesButton"
             android:background="@color/transparent"
-            android:gravity="center"
+            android:layout_alignParentEnd="true"
             android:onClick="createListing"
             android:scaleType="fitCenter"
             android:src="@drawable/account_icon" />

--- a/app/src/main/res/layout/property_card.xml
+++ b/app/src/main/res/layout/property_card.xml
@@ -7,10 +7,13 @@
 
     <androidx.cardview.widget.CardView
         android:id="@+id/property_card"
-        android:layout_width="385dp"
-        android:layout_height="540dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_gravity="top|center"
-        android:layout_marginTop="5dp"
+        android:layout_marginTop="15dp"
+        android:layout_marginStart="15dp"
+        android:layout_marginEnd="15dp"
+        android:layout_marginBottom="15dp"
         card_view:cardCornerRadius="8dp">
 
         <ImageView


### PR DESCRIPTION
I'm just going to paste what I wrote on discord: I centered the navigation bar icons and evenly spaced them. I also made it so that the ends of the content in the app bar are always 15dp away from the edges (same as the card boundaries). The search bar will change it's size to accommodate other screens because of these parameters. I applied the same overall logic to the property card itself.